### PR TITLE
Fix a DNF check

### DIFF
--- a/lib/CPAN/Plugin/Sysdeps.pm
+++ b/lib/CPAN/Plugin/Sysdeps.pm
@@ -410,13 +410,12 @@ sub _detect_dnf {
     require Symbol;
     my $err = Symbol::gensym();
     my $fh;
-    eval {
+    return eval {
 	    if (my $pid = IPC::Open3::open3(undef, $fh, $err, @cmd)) {
 		    waitpid $pid, 0;
 		    return $? == 0;
 		}
     };
-    return;
 }
 
 sub _find_missing_deb_packages {


### PR DESCRIPTION
Return statements in an eval block, in this case the "return $? == 0;"
statement, are evaluated in a context of the eval keyword. In this case
it's a void context and thus the return value gets discarded. Then the
final return after eval always returns false.

As a result the _detect_dnf() never worked. This patch fixes it.