### PR TITLE
mapping update for X11::XCB

### DIFF
--- a/lib/CPAN/Plugin/Sysdeps/Mapping.pm
+++ b/lib/CPAN/Plugin/Sysdeps/Mapping.pm
@@ -3743,7 +3743,9 @@ sub mapping {
       [os_freebsd,
        [package => ['expat', 'pkgconf', 'xcb-proto', 'xcb-util-wm']]],
       [like_debian,
-       [package => ['libxcb-ewmh-dev', 'libxcb-icccm4-dev', 'libxcb-randr0-dev', 'libxcb-render0-dev', 'libxcb-util-dev', 'libxcb-util0-dev', 'libxcb-xinerama0-dev', 'libxcb-xinput-dev', 'libxcb-xkb-dev', 'libxcb-xtest0-dev', 'libxcb1-dev', 'xcb-proto', 'xsltproc']]]],
+       [package => ['libxcb-composite0-dev', 'libxcb-ewmh-dev', 'libxcb-icccm4-dev', 'libxcb-randr0-dev',
+        'libxcb-render0-dev', 'libxcb-util-dev', 'libxcb-util0-dev', 'libxcb-xinerama0-dev', 'libxcb-xinput-dev',
+        'libxcb-xkb-dev', 'libxcb-xtest0-dev', 'libxcb1-dev', 'xcb-proto', 'xsltproc']]]],
 
      [cpanmod => 'X11::Xlib',
       [os_freebsd,


### PR DESCRIPTION
Add XComposite dependency for Debian required for X11::XCB 0.23+