### PR TITLE
mapping update for X11::XCB (fedora support)

### DIFF
--- a/lib/CPAN/Plugin/Sysdeps/Mapping.pm
+++ b/lib/CPAN/Plugin/Sysdeps/Mapping.pm
@@ -3786,6 +3786,8 @@ sub mapping {
      [cpanmod => 'X11::XCB',
       [os_freebsd,
        [package => ['expat', 'pkgconf', 'xcb-proto', 'xcb-util-wm']]],
+      [like_fedora,
+       [package => ['expat-devel', 'libxcb-devel', 'xcb-util-devel', 'xcb-util-wm-devel', 'xcb-proto']]],
       [like_debian,
        [before_ubuntu_focal,
 	[package => []]],


### PR DESCRIPTION
Hellow, Slaven!

I did include `fedora` support for `X11::XCB` as some of your checkers run on it. 
As usual, many thanks for your work and contribution to open source!

Best wishes, 
Sergei