### PR TITLE
Update FreeType dev package mapping for Debian >= trixie and Ubuntu >= 24.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,6 +139,7 @@ jobs:
     - name: Install perl and more on OpenSUSE
       run: |
         set -e
+        zypper --non-interactive refresh
         zypper install -y make perl perl-App-cpanminus lsb-release
       if: "matrix.dist == 'opensuse/tumbleweed' || matrix.dist == 'opensuse/leap'"
     - name: Install perl and more on Alpine

--- a/lib/CPAN/Plugin/Sysdeps.pm
+++ b/lib/CPAN/Plugin/Sysdeps.pm
@@ -1048,7 +1048,7 @@ system:
 
 On a Debian system the output will look like:
 
-    libfreetype6-dev
+    libfreetype-dev
     libgif-dev
     libpng12-dev
     libjpeg-dev

--- a/lib/CPAN/Plugin/Sysdeps/Mapping.pm
+++ b/lib/CPAN/Plugin/Sysdeps/Mapping.pm
@@ -1956,7 +1956,7 @@ sub mapping {
 	[package => [qw(libfreetype6-dev libgif-dev libpng12-dev libjpeg-dev), 'libtiff5-dev | libtiff4-dev']]],
        [linuxdistrocodename => [qw(jessie xenial)],
 	[package => [qw(libfreetype6-dev libgif-dev libpng12-dev libjpeg-dev libtiff5-dev)]]],
-       [package => [qw(libfreetype6-dev libgif-dev libpng-dev libjpeg-dev libtiff5-dev)]],
+       [package => ['libfreetype-dev | libfreetype6-dev', qw(libgif-dev libpng-dev libjpeg-dev libtiff5-dev)]],
       ],
       [like_fedora,
        [package => [qw(freetype-devel giflib-devel libpng-devel libjpeg-turbo-devel libtiff-devel)]]],
@@ -2921,7 +2921,7 @@ sub mapping {
      [cpanmod => 'OpenGL::FTGL',
       [like_debian,
        # but does not work, lookup into wrong freetype directory
-       [package => ['libftgl-dev', 'libfreetype6-dev']]]],
+       [package => ['libftgl-dev', 'libfreetype-dev | libfreetype6-dev']]]],
 
      [cpanmod => 'OpenGL::GLFW',
       [os_freebsd,
@@ -3547,7 +3547,7 @@ sub mapping {
        [osvers => {'<', freebsd_new_jpeg_osvers}, [package => [qw(freetype2 libXft libX11 png), freebsd_old_jpeg]]],
        [package => [qw(freetype2 libXft libX11 png), freebsd_new_jpeg]]],
       [like_debian,
-       [package => [qw(libx11-dev libfreetype6-dev libxft-dev libpng-dev libz-dev libjpeg-dev)]]],
+       [package => ['libx11-dev', 'libfreetype-dev | libfreetype6-dev', qw(libxft-dev libpng-dev libz-dev libjpeg-dev)]]],
       [like_fedora,
        [package => [qw(libX11-devel libXft-devel libpng-devel zlib-devel libjpeg-devel)]]],
      ],


### PR DESCRIPTION
Debian trixie and Ubuntu 24.04 (noble) require `libfreetype-dev` instead of `libfreetype6-dev`. I have updated the mappings for `Imager`, `OpenGL::FTGL`, and `Tk` in `lib/CPAN/Plugin/Sysdeps/Mapping.pm` to use `'libfreetype-dev | libfreetype6-dev'`. This ensures that newer systems find the preferred package while older systems can still fall back to the legacy name. Verified with tests and code review.

---
*PR created automatically by Jules for task [10612295867136311291](https://jules.google.com/task/10612295867136311291) started by @eserte*